### PR TITLE
Rename CBL0033J to CBL0003J

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -2755,13 +2755,13 @@ In summary, this chapter should provide the necessary foundation to understand s
 
 ## Lab
 
-This lab utilizes COBOL program CBL0003, located within your id.CBL data set, as well as JCL job CBL0003J, located within your id.JCL data set.  The JCL jobs are used to compile and execute the COBOL programs, as discussed in previous chapters.
+This lab utilizes COBOL program CBL0033, located within your id.CBL data set, as well as JCL job CBL0033J, located within your id.JCL data set.  The JCL jobs are used to compile and execute the COBOL programs, as discussed in previous chapters.
 
 #### Using VSCode and Zowe Explorer
 
-1. Take a moment and look over the source code of the COBOL program provided: CBL0003. 
+1. Take a moment and look over the source code of the COBOL program provided: CBL0033. 
 
-2. Compare CBL0003 with CBL0001 and CBL0002 from the previous lab. Do you notice the differences? 
+2. Compare CBL0033 with CBL0001 and CBL0002 from the previous lab. Do you notice the differences? 
 
    a. Observe the new COUNTER line within the WORKING-STORAGE > DATA DIVISION.
 
@@ -2771,11 +2771,11 @@ This lab utilizes COBOL program CBL0003, located within your id.CBL data set, as
 
    c. These paragraphs perform the same loop as in CBL0001, but using the PERFORM statement in different ways. The CALLING-SUBPROGRAM calls the HELLO program, already presented in the second Lab of this course.
 
-3. Submit job: CBL0003J. This JCL first compiles the program HELLO,
-then compiles CBL0003 and links the result of both compilations
+3. Submit job: CBL0033J. This JCL first compiles the program HELLO,
+then compiles CBL0033 and links the result of both compilations
 together. 
 
-4. View CBL0003J output using the JOBS section and open RUN:PRTLINE, observe the report is identical to CBL0001.
+4. View CBL0033J output using the JOBS section and open RUN:PRTLINE, observe the report is identical to CBL0001.
 
 5. View output of target program HELLO using the JOBS section and open RUN:SYSOUT. 
 

--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -2131,7 +2131,7 @@ The lab associated with this chapter demonstrates the ‘end-of-file’ COBOL co
 
 - CBL0002J
 
-- CBL0033J
+- CBL0003J
 
 ![](Images/image133.png)
 
@@ -2178,10 +2178,10 @@ The lab associated with this chapter demonstrates the ‘end-of-file’ COBOL co
 
    - RUN:PRTLINE(103) is the COBOL program execution output (if correction is successful)
 
-10.  Submit job, JCL(CBL0033J), using the DATA SET section.
+10.  Submit job, JCL(CBL0003J), using the DATA SET section.
 
 
-11.  View CBL0033J ABENDU4038 output, using the JOBS section:
+11.  View CBL0003J ABENDU4038 output, using the JOBS section:
 
       - View the IGZ00355 abend message in RUN:SYSOUT(104) from the COBOL program execution output.
 
@@ -2193,7 +2193,7 @@ The lab associated with this chapter demonstrates the ‘end-of-file’ COBOL co
 
  
 
-12.  Fix this error by editing JCL(CBL0033J):
+12.  Fix this error by editing JCL(CBL0003J):
 
      - Determine the DDNAME needed, but missing or misspelled. 
 
@@ -2201,17 +2201,17 @@ The lab associated with this chapter demonstrates the ‘end-of-file’ COBOL co
 
  
 
-13.  Re-submit job, JCL(CBL0033J), using the DATA SET section.
+13.  Re-submit job, JCL(CBL0003J), using the DATA SET section.
 
  
 
-14.  View CBL0033J output using the JOBS section, your output should look like Figure  12.
+14.  View CBL0003J output using the JOBS section, your output should look like Figure  12.
 
      - RUN:PRTLINE - COBOL program execution output (if correction is successful)
 
 ![](Images/image138.png)
 
-*Figure  12.  RUN:PRTLINE(103) for JCL(CBL0033J)*
+*Figure  12.  RUN:PRTLINE(103) for JCL(CBL0003J)*
 
 **Lab hints**
 
@@ -2219,7 +2219,7 @@ The lab associated with this chapter demonstrates the ‘end-of-file’ COBOL co
 
 ![](Images/image140.png)
 
-*Figure  13.  Error in id.JCL(CBL0033J).jcl*
+*Figure  13.  Error in id.JCL(CBL0003J).jcl*
 
 \newpage
 

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0033.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0033.cobol
@@ -1,7 +1,7 @@
       *-----------------------
        IDENTIFICATION DIVISION.
       *-----------------------
-       PROGRAM-ID.    CBL0003
+       PROGRAM-ID.    CBL0033
        AUTHOR.        Otto B. Fun.
       *--------------------
        ENVIRONMENT DIVISION.

--- a/COBOL Programming Course #1 - Getting Started/Labs/jcl/CBL0003J.jcl
+++ b/COBOL Programming Course #1 - Getting Started/Labs/jcl/CBL0003J.jcl
@@ -1,27 +1,18 @@
 //CBL0003J JOB 1,NOTIFY=&SYSUID
 //***************************************************/
 //COBRUN  EXEC IGYWCL
-//COBOL.SYSIN  DD DSN=&SYSUID..CBL(HELLO),DISP=SHR
-//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(HELLO),DISP=SHR
+//COBOL.SYSIN  DD DSN=&SYSUID..CBL(CBL0001),DISP=SHR
+//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(CBL0001),DISP=SHR
 //***************************************************/
 // IF RC = 0 THEN
 //***************************************************/
-//COBRUN  EXEC IGYWCL
-//COBOL.SYSIN  DD DSN=&SYSUID..CBL(CBL0003),DISP=SHR
-//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(CBL0003),DISP=SHR
-//LKED.SYSLIB  DD DSN=&SYSUID..LOAD(HELLO),DISP=SHR
-//***************************************************/
-// IF RC = 0 THEN
-//***************************************************/
-//RUN     EXEC PGM=CBL0003
+//RUN     EXEC PGM=CBL0001
 //STEPLIB   DD DSN=&SYSUID..LOAD,DISP=SHR
-//ACCTREC   DD DSN=&SYSUID..DATA,DISP=SHR
+//ACCTREX   DD DSN=&SYSUID..DATA,DISP=SHR
 //PRTLINE   DD SYSOUT=*,OUTLIM=15000
 //SYSOUT    DD SYSOUT=*,OUTLIM=15000
 //CEEDUMP   DD DUMMY
 //SYSUDUMP  DD DUMMY
 //***************************************************/
-// ELSE
-// ENDIF
 // ELSE
 // ENDIF

--- a/COBOL Programming Course #1 - Getting Started/Labs/jcl/CBL0033J.jcl
+++ b/COBOL Programming Course #1 - Getting Started/Labs/jcl/CBL0033J.jcl
@@ -1,18 +1,27 @@
-//CBL0003J JOB 1,NOTIFY=&SYSUID
+//CBL0033J JOB 1,NOTIFY=&SYSUID
 //***************************************************/
 //COBRUN  EXEC IGYWCL
-//COBOL.SYSIN  DD DSN=&SYSUID..CBL(CBL0001),DISP=SHR
-//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(CBL0001),DISP=SHR
+//COBOL.SYSIN  DD DSN=&SYSUID..CBL(HELLO),DISP=SHR
+//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(HELLO),DISP=SHR
 //***************************************************/
 // IF RC = 0 THEN
 //***************************************************/
-//RUN     EXEC PGM=CBL0001
+//COBRUN  EXEC IGYWCL
+//COBOL.SYSIN  DD DSN=&SYSUID..CBL(CBL0033),DISP=SHR
+//LKED.SYSLMOD DD DSN=&SYSUID..LOAD(CBL0033),DISP=SHR
+//LKED.SYSLIB  DD DSN=&SYSUID..LOAD(HELLO),DISP=SHR
+//***************************************************/
+// IF RC = 0 THEN
+//***************************************************/
+//RUN     EXEC PGM=CBL0033
 //STEPLIB   DD DSN=&SYSUID..LOAD,DISP=SHR
-//ACCTREX   DD DSN=&SYSUID..DATA,DISP=SHR
+//ACCTREC   DD DSN=&SYSUID..DATA,DISP=SHR
 //PRTLINE   DD SYSOUT=*,OUTLIM=15000
 //SYSOUT    DD SYSOUT=*,OUTLIM=15000
 //CEEDUMP   DD DUMMY
 //SYSUDUMP  DD DUMMY
 //***************************************************/
+// ELSE
+// ENDIF
 // ELSE
 // ENDIF


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

This would fix #198. It appears #153 is not merged into the mainframe system, thus resulting in confusion with the PDF content.

Personally, I would prefer that the new CBL0003.cbl be renamed to something else or adopt the CBL0033 naming (8af11a09e2218c03901ebf877b40fbceb73e02b6) to prevent confusion with existing tutorials and PDF which are already on circulation (such as Coursera, Pluralsight and the IBM Learning Platform).