### PR TITLE
Replace STOP RUN with GOBACK

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/ADDAMT.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/ADDAMT.cobol
@@ -34,4 +34,4 @@
                ACCEPT MORE-DATA
                INSPECT MORE-DATA CONVERTING 'noyes' to 'NOYES'
            END-PERFORM
-           STOP RUN.
+           GOBACK.

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0001.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0001.cobol
@@ -77,7 +77,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0002.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0002.cobol
@@ -58,7 +58,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0003.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0003.cobol
@@ -105,8 +105,8 @@
        3000-CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
-      *Without STOP RUN here, the next paragraphs would
+           GOBACK.
+      *Without GOBACK here, the next paragraphs would
       *execute once more
        3000-CLOSE-STOP-END.
       *

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0004.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0004.cobol
@@ -144,7 +144,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0005.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0005.cobol
@@ -144,7 +144,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0006.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0006.cobol
@@ -134,7 +134,7 @@
            WRITE PRINT-REC FROM CLIENTS-PER-STATE.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0007.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0007.cobol
@@ -134,7 +134,7 @@
            WRITE PRINT-REC FROM CLIENTS-PER-STATE.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0008.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0008.cobol
@@ -156,7 +156,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0009.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0009.cobol
@@ -156,7 +156,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0010.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0010.cobol
@@ -159,7 +159,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0011.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0011.cobol
@@ -146,7 +146,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0012.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/CBL0012.cobol
@@ -141,7 +141,7 @@
        CLOSE-STOP.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/COBOL.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/COBOL.cobol
@@ -45,7 +45,7 @@
            PERFORM A000-COUNT 10    TIMES.
            PERFORM A000-DONE.
            CLOSE   PRT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        A000-COUNT.
            ADD 1 TO PGM-COUNT.

--- a/COBOL Programming Course #1 - Getting Started/Labs/cbl/HELLO.cobol
+++ b/COBOL Programming Course #1 - Getting Started/Labs/cbl/HELLO.cobol
@@ -2,4 +2,4 @@
        PROGRAM-ID. HELLO.
        PROCEDURE DIVISION.
            DISPLAY 'HELLO WORLD!'.
-           STOP RUN.
+           GOBACK.

--- a/COBOL Programming Course #2 - Advanced Topics/Challenges/Debugging/cbl/CBL0106.cbl
+++ b/COBOL Programming Course #2 - Advanced Topics/Challenges/Debugging/cbl/CBL0106.cbl
@@ -150,7 +150,7 @@
            PERFORM WRITE-OVERLIMIT.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC

--- a/COBOL Programming Course #2 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
+++ b/COBOL Programming Course #2 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
@@ -150,7 +150,7 @@
            PERFORM WRITE-OVERLIMIT.
            CLOSE ACCT-REC.
            CLOSE PRINT-LINE.
-           STOP RUN.
+           GOBACK.
       *
        READ-RECORD.
            READ ACCT-REC


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

One of the issue with having `STOP RUN` is that it causes problems with subroutine CALL. In particular if a user decide to call a subroutine twice, and the subroutine contain a `STOP RUN`, the entire thing will terminate before the second execution.

In particular, this may have causes this issue on Slack: https://openmainframeproject.slack.com/archives/C011NE32Z1T/p1611697726073500

Thus, I believe it's in the best interest to replace all occurrence of `STOP RUN` to `GOBACK` since the programs will terminate more gracefully (i.e. the CALL-ed program will return control back to the caller instead of terminating everything).