### PR TITLE
Fix PERFORM with UNTIL statement format

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -2638,13 +2638,13 @@ In this case, the Boolean condition is evaluated before the loop is executed.  H
 
 
 ```
- PERFORM UNTIL COUNTER = 10 WITH TEST AFTER
+ PERFORM WITH TEST AFTER UNTIL COUNTER = 10
   ADD 1 TO COUNTER GIVING COUNTER
   MOVE COUNTER TO MSG-TO-WRITE
   WRITE PRINT-REC
  END-PERFORM.
 ```
-*Example 15.  PERFORM UNTIL WITH TEST AFTER*
+*Example 15.  PERFORM WITH TEST AFTER UNTIL*
  
 This would be similar to a "do while" loop in Java:
 


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

This pull request will fix #122. Thanks @Todesangst !

Note the format below from the Enterprise COBOL for z/OS V6.3 Language Reference:

![image](https://user-images.githubusercontent.com/13640520/111219608-34025200-8613-11eb-8e67-9d2c7901f869.png)

`WITH TEST AFTER` must come before `UNTIL COUNTER=10` or the user will get RC 12 with IGYPS2072-S.
