### PR TITLE
Fix examples on Conditional Names

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -3192,11 +3192,36 @@ A PERFORM with UNTIL phrase is a conditional expression.  In the UNTIL phrase fo
 
 
 ```
-PERFORM SAY-SOMETHING-DIFFERENT BY FACIAL-EXP UNTIL 'HAPPY'
+WORKING-STORAGE.
+01 FACIAL-EXP    PIC X(11) VALUE SPACES.
+   88 HAPPY      VALUE 'HAPPY'.
+....
+....
+PROCEDURE DIVISION.
+....
+....
+PERFORM SAY-SOMETHING-DIFFERENT UNTIL HAPPY
 END-PERFORM.
 ```
 
-*Example 5. PERFORM statement*
+*Example 5. PERFORM statement with 88-level conditional name*
+
+
+It is also possible to use PERFORM statement without the use of a 88-level conditional name, observe Example 6.
+
+```
+WORKING-STORAGE.
+01 FACIAL-EXP    PIC X(11) VALUE SPACES.
+....
+....
+PROCEDURE DIVISION.
+....
+....
+PERFORM SAY-SOMETHING-DIFFERENT UNTIL FACIAL-EXP = "HAPPY"
+END-PERFORM.
+```
+
+*Example 6. PERFORM statement without 88-level conditional name*
  
 
 ### SEARCH statements
@@ -3205,11 +3230,20 @@ The SEARCH statement searches a table for an element that satisfies the specifie
 
 
 ```
+WORKING-STORAGE.
+01  FACIAL-EXP-TABLE REDEFINES FACIAL-EXP-LIST.
+    05  FACIAL-EXP  PIC X(11) OCCURS n TIMES INDEXED BY INX-A.
+        88  HAPPY VALUE "HAPPY".
+....
+....
+PROCEDURE DIVISION.
+....
+....
 SEARCH FACIAL-EXP
-WHEN 'HAPPY' STOP RUN
+WHEN HAPPY(INX-A) DISPLAY 'I am glad you are happy'
 END-SEARCH
 ```
-*Example 6. SEARCH WHEN statement*
+*Example 7. SEARCH WHEN statement*
            
 
 ## Conditions

--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -3226,7 +3226,7 @@ END-PERFORM.
 
 ### SEARCH statements
 
-The SEARCH statement searches a table for an element that satisfies the specified condition and adjusts the associated index to indicate that element.  Tables, effectively an array of values, are created with an OCCURS clause applied to WORK-STORAGE data-names.  A WHEN clause is utilized in SEARCH statements to verify if the element searched for satisfies the specified condition.  Assuming FACIAL-EXP has many possible values, then SEARCH WHEN is an alternative conditional expression, observe Example 6.
+The SEARCH statement searches a table for an element that satisfies the specified condition and adjusts the associated index to indicate that element.  Tables, effectively an array of values, are created with an OCCURS clause applied to WORK-STORAGE data-names.  A WHEN clause is utilized in SEARCH statements to verify if the element searched for satisfies the specified condition.  Assuming FACIAL-EXP has many possible values, then SEARCH WHEN is an alternative conditional expression, observe Example 7.
 
 
 ```


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

This PR fixes the examples on Conditional Names to enable compilation given a sufficient effort from the course takers, and thus fix #50.

In particular, 

- I can't see a way to use PERFORM with a BY without it being a PERFORM with VARYING phrase. Thus, the example is rewritten accordingly based on @OldGuy86's suggestion, and a new example is added to cover the use case of without 88-level conditional name.
- Fixed the SEARCH statements to incorporate the tables and index along with using 88-level conditional name.