### PR TITLE
Add chapter on multithreading

### DIFF
--- a/COBOL Programming Course #2 - Advanced Topics/COBOL Programming Course #2 - Advanced Topics.md
+++ b/COBOL Programming Course #2 - Advanced Topics/COBOL Programming Course #2 - Advanced Topics.md
@@ -610,11 +610,11 @@ However, automatic serialization is not applied to statements specified with the
 
 ### File-definition storage
 
-On all programs invocation, the storage associated with file definition (such as FD records) is allocated and available in its last-used state. Therefore, all threads of execution will share this storage. You can depend on automatic serialization for this storage during the execution of the statements mentioned previously, but not between uses of the statements.
+Upon program invocation, the storage associated with file definition (such as FD records) is allocated and available in its last-used state. Therefore, all threads of execution will share this storage. You can depend on automatic serialization for this storage during the execution of the statements mentioned previously, but not between uses of the statements.
 
 ### Serializing file access with multithreading
 
-To take advantage of automatic serialization, we can use one of the recommended following file organizations and usage patterns when we access files in threaded programs.
+To take advantage of automatic serialization, we can use one of the recommended following file organization and usage patterns when we access files in threaded programs.
 
 Recommended file organizations:
 - Sequential organization


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

This PR adds a chapter on multithreading. Logically, this chapter should be placed on a later section of the course, after subprograms and compiler options, but before object-oriented COBOL.

Contents are adapted from the Programming Guide.

Labs for the chapter are pending as some other programs are required to handle the threads (maybe C or Java).
