### PR TITLE
Move to the LF Projects, LLC CoC, which aligns with the one used in the charter

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-All participants agree to abide by the Code of Conduct available at https://github.com/openmainframeproject/tac/blob/master/CODE_OF_CONDUCT.md. Please contact conduct@openmainframeproject.org to report any violations or concerns.
+All participants agree to abide by the Code of Conduct available at https://lfprojects.org/policies/code-of-conduct/. Please contact conduct@openmainframeproject.org to report any violations or concerns.


### PR DESCRIPTION
Signed-off-by: John Mertic <jmertic@linuxfoundation.org>
