### PR TITLE
Fix PERFORM VARYING AFTER example

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -3050,7 +3050,7 @@ do{
     //move counter to msg-to-write
     //write print-rec
 }
-While(counter != 10);
+while(counter != 10);
 ```
 *Example 16.  Java while loop*
 
@@ -3066,14 +3066,13 @@ END-PERFORM.
 ```
 *Example 17.  Basic loop*
 
-In this example, the variable counter is tested to see if it equals 11, as long as it doesn't then it is incremented, and the sentences nested within the perform statement are executed.  This construct can be extended, exemplified in Example 18.
+In this example, the variable counter is tested to see if it equals 11, as long as it doesn't then it is incremented, and the statements nested within the perform statement are executed.  This construct can be extended, exemplified in Example 18. However, in this example, we can only execute paragraphs instead of nested statements.
 
 
 ```
-PERFORM VARYING COUNTER FROM 01 BY 1 UNTIL COUNTER EQUAL 11
-     AFTER COUNTER-2 FROM 01 BY 1 UNTIL COUNTER-2 EQUAL 5
-...
-END-PERFORM.
+PERFORM 1000-PARAGRAPH-A
+    VARYING COUNTER FROM 01 BY 1 UNTIL COUNTER EQUAL 11
+    AFTER COUNTER-2 FROM 01 BY 1 UNTIL COUNTER-2 EQUAL 5.
 ```
 *Example 18.  Extended loop*
 
@@ -3081,9 +3080,8 @@ This may seem complex, but compare it to this Java pseudo-code:
 
 ```
 for(int counter = 0; counter < 11; counter++){
-    for(int counter2 = 0; counter2 < 5; counter2++{
-       //move counter to msg-to-write
-       //write print-rec
+    for(int counter2 = 0; counter2 < 5; counter2++){
+       paragraphA();
     }
 }
 ```


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <13640520+tanto259@users.noreply.github.com>

## Proposed changes

This PR edit the example of the PERFORM VARYING AFTER example to reflect that it only accepts out-of-line statement contained within a paragraph.

From the Language Reference, `phrase 2` is only available via `PERFORM procedure-statement-1`:

![image](https://user-images.githubusercontent.com/13640520/162164369-0e35a4fa-42cd-4fff-8a2e-e17ae4e0119c.png)


## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [X] Bug fix (change which fixes one or more issues)
- [ ] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [ ] Documentation (change which modifies documentation related to the course)
- [ ] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [X] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [X] I have included a title and description for this PR
- [X] I have DCO-signed all of my commits that are included in this PR
- [X] I have tested it manually and there are no regressions found
- [ ] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)