### PR TITLE
Add CODEPAGE parameter to avoid waring; add missing NOTIFY statement; use 88-level conditional names for assignments

### DIFF
--- a/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/SRCHBIN.cobol
+++ b/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/SRCHBIN.cobol
@@ -68,6 +68,6 @@
       *
        READ-RECORD.
            READ ACCT-REC
-           AT END MOVE 'Y' TO LASTREC
+           AT END SET END-OF-FILE TO TRUE
            END-READ.
       *

--- a/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/SRCHSER.cobol
+++ b/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/SRCHSER.cobol
@@ -67,6 +67,6 @@
       *
        READ-RECORD.
            READ ACCT-REC
-           AT END MOVE 'Y' TO LASTREC
+           AT END SET END-OF-FILE TO TRUE
            END-READ.
       *

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB22.cbl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB22.cbl
@@ -101,7 +101,7 @@
                 OPEN INPUT  RECIN.                                      
                 OPEN OUTPUT REPOUT.                                     
                 READ RECIN  RECORD INTO IOAREA                          
-                   AT END MOVE 'N' TO INPUT-SWITCH.                     
+                   AT END SET NOMORE-INPUT TO TRUE.
                 PERFORM PROCESS-INPUT                                   
                    UNTIL NOMORE-INPUT.                                  
       *                                                                 
@@ -116,7 +116,7 @@
                 ELSE                                                    
                    PERFORM GET-SPECIFIC.                                
                 READ RECIN  RECORD INTO IOAREA                          
-                   AT END MOVE 'N' TO INPUT-SWITCH.                     
+                   AT END SET NOMORE-INPUT TO TRUE.
       *                                                                 
        GET-ALL.                                                         
                 EXEC SQL OPEN CUR1  END-EXEC.                           

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB23.cbl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB23.cbl
@@ -97,7 +97,7 @@
                 OPEN INPUT  CARDIN.                                     
                 OPEN OUTPUT REPOUT.                                     
                 READ CARDIN RECORD INTO IOAREA                          
-                   AT END MOVE 'N' TO INPUT-SWITCH.                     
+                   AT END SET NOMORE-INPUT TO TRUE.
                 PERFORM PROCESS-INPUT                                   
                    UNTIL NOMORE-INPUT.                                  
        PROG-END.                                                        
@@ -110,7 +110,7 @@
                 ELSE                                                    
                    PERFORM GET-SPECIFIC.                                
                 READ CARDIN RECORD INTO IOAREA                          
-                   AT END MOVE 'N' TO INPUT-SWITCH.                     
+                   AT END SET NOMORE-INPUT TO TRUE.
        GET-ALL.                                                         
                 EXEC SQL OPEN CUR1  END-EXEC.                           
                 EXEC SQL FETCH CUR1  INTO :CUSTOMER-RECORD END-EXEC.    

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB21C.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB21C.jcl
@@ -3,7 +3,7 @@
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0
 //***************************************************/
-//COMPILE  EXEC DB2CBL,MBR=CBLDB21
+//COMPILE  EXEC DB2CBL,MBR=CBLDB21,PARM=('SQL,CODEPAGE(1047)')
 //BIND.SYSTSIN  DD *,SYMBOLS=CNVTSYS
  DSN SYSTEM(DBCG)
  BIND PLAN(&SYSUID) PKLIST(&SYSUID..*) MEMBER(CBLDB21) -

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB22C.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB22C.jcl
@@ -3,7 +3,7 @@
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0
 //***************************************************/
-//COMPILE  EXEC DB2CBL,MBR=CBLDB22
+//COMPILE  EXEC DB2CBL,MBR=CBLDB22,PARM=('SQL,CODEPAGE(1047)')
 //BIND.SYSTSIN  DD *,SYMBOLS=CNVTSYS
  DSN SYSTEM(DBCG)
  BIND PLAN(&SYSUID) PKLIST(&SYSUID..*) MEMBER(CBLDB22) -

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB23C.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB23C.jcl
@@ -3,7 +3,7 @@
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0
 //***************************************************/
-//COMPILE  EXEC DB2CBL,MBR=CBLDB23
+//COMPILE  EXEC DB2CBL,MBR=CBLDB23,PARM=('SQL,CODEPAGE(1047)')
 //BIND.SYSTSIN  DD *,SYMBOLS=CNVTSYS
  DSN SYSTEM(DBCG)
  BIND PLAN(&SYSUID) PKLIST(&SYSUID..CBLDB23) MEMBER(CBLDB23) -

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CRETBL.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CRETBL.jcl
@@ -1,4 +1,4 @@
-//CREATE1   JOB 1                                                       
+//CREATE1   JOB 1,NOTIFY=&SYSUID
 //***************************************************/
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/DB2SETUP.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/DB2SETUP.jcl
@@ -1,4 +1,4 @@
-//DB2SETUP JOB   1
+//DB2SETUP JOB   1,NOTIFY=&SYSUID
 //***************************************************/
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/DBRMLIB.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/DBRMLIB.jcl
@@ -1,4 +1,4 @@
-//DBRMLIB JOB 1
+//DBRMLIB JOB 1,NOTIFY=&SYSUID
 //***************************************************/
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/SELTBL.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/SELTBL.jcl
@@ -1,4 +1,4 @@
-//SELTBL  JOB 1                                                         
+//SELTBL  JOB 1,NOTIFY=&SYSUID
 //***************************************************/
 //* Copyright Contributors to the COBOL Programming Course 
 //* SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
## Proposed changes
- Add missing NOTIFY statement:
Without NOTIFY statement the user won't get notification, when the job completes execution.

- Add CODEPAGE parameter to avoid waring:
If codepage is not given for COBOL SQL compiler, then the following warning message is issued:
"IGYOS4078-W   DSNH4791I DSNHPSRV  CCSID 1140 IS USED TO PROCESS SQL, BUT DSNHDECP HAS EBCDIC CCSID 1047 IN EFFECT"

- Since we already use the 88-level conditional data names to detect the end of a loop, therefore we should use them for assignments as well.

## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [x] Bug fix (change which fixes one or more issues)
- [x] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [ ] Documentation (change which modifies documentation related to the course)
- [ ] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [x] I have included a title and description for this PR
- [x] I have DCO-signed all of my commits that are included in this PR
- [x] I have tested it manually and there are no regressions found
- [ ] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)