### PR TITLE
Error handling after increasing the array index

### DIFF
--- a/COBOL Programming Course #3 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
+++ b/COBOL Programming Course #3 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
@@ -44,9 +44,10 @@
       *
        WORKING-STORAGE SECTION.
        01  Filler.
-           05 LASTREC          PIC X VALUE SPACE.
+           05 LASTREC          PIC X          VALUE SPACE.
            05 DISP-SUB1        PIC 9999.
            05 SUB1             PIC 99.
+           05 OVERLIMIT-MAX    PIC S9(4) COMP VALUE 20.
 
          01 OVERLIMIT.
            03 FILLER OCCURS 20 TIMES.
@@ -136,7 +137,7 @@
            WRITE PRINT-REC FROM HEADER-3.
            WRITE PRINT-REC FROM HEADER-4.
            MOVE SPACES TO PRINT-REC.
-           MOVE 1 TO SUB1.
+           MOVE 0 TO SUB1.
       *
        READ-NEXT-RECORD.
            PERFORM READ-RECORD
@@ -162,11 +163,19 @@
       *
        IS-OVERLIMIT.
            IF ACCT-LIMIT < ACCT-BALANCE THEN
+               ADD 1 TO SUB1
+      * Check if there is enough space in the array, in case the input 
+      * file changes again. A handled error is easier to find and fix 
+      * than a buffer overwrite error.
+               IF SUB1 > OVERLIMIT-MAX THEN
+                   DISPLAY 'OVERFOLW TABLE OVERLIMIT'
+                   MOVE 1000 TO RETURN-CODE
+                   STOP RUN
+               END-IF
                MOVE ACCT-LIMIT TO OL-ACCT-LIMIT(SUB1)
                MOVE ACCT-BALANCE TO OL-ACCT-BALANCE(SUB1)
                MOVE LAST-NAME TO OL-LASTNAME(SUB1)
                MOVE FIRST-NAME TO OL-FIRSTNAME(SUB1)
-               ADD 1 TO SUB1
             END-IF.
       *
        IS-STATE-VIRGINIA.
@@ -175,7 +184,7 @@
            END-IF.
       *
        WRITE-OVERLIMIT.
-           IF SUB1 = 1 THEN
+           IF SUB1 = 0 THEN
                MOVE OVERLIMIT-STATUS TO PRINT-REC
                WRITE PRINT-REC
            ELSE

--- a/COBOL Programming Course #3 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
+++ b/COBOL Programming Course #3 - Advanced Topics/Challenges/Debugging/cbl/CBL0106C.cbl
@@ -168,7 +168,7 @@
       * file changes again. A handled error is easier to find and fix 
       * than a buffer overwrite error.
                IF SUB1 > OVERLIMIT-MAX THEN
-                   DISPLAY 'OVERFOLW TABLE OVERLIMIT'
+                   DISPLAY 'OVERFLOW TABLE OVERLIMIT'
                    MOVE 1000 TO RETURN-CODE
                    STOP RUN
                END-IF


### PR DESCRIPTION
Signed-off-by: Janos Varga <113785741+vargajb@users.noreply.github.com>

## Proposed changes

- After increasing the array index, an error handling must be included, because if the input is extended later again, we can look for the error again. A handled error is easier to find and fix than a buffer overwrite error. 
- Table index should start from 0, because it indicates better that the table is empty.

Fixes # (issue)

## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [x] Bug fix (change which fixes one or more issues)
- [ ] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [ ] Documentation (change which modifies documentation related to the course)
- [ ] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [x] I have included a title and description for this PR
- [x] I have DCO-signed all of my commits that are included in this PR
- [x] I have tested it manually and there are no regressions found
- [x] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)