### PR TITLE
Handling SQL error codes

### DIFF
--- a/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB23.cbl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/cbl/CBLDB23.cbl
@@ -50,6 +50,17 @@
       * SQL INCLUDE FOR SQLCA                             *             
       *****************************************************             
                 EXEC SQL INCLUDE SQLCA  END-EXEC.                       
+      *****************************************************
+      * DECLARATIONS FOR SQL ERROR HANDLING               *
+      *****************************************************
+       01 ERROR-MESSAGE.
+           02 ERROR-LEN      PIC S9(4)  COMP VALUE +1320.
+           02 ERROR-TEXT     PIC X(132) OCCURS 10 TIMES
+                                        INDEXED BY ERROR-INDEX.
+       77 ERROR-TEXT-LEN     PIC S9(9)  COMP VALUE +132.
+       77 ERROR-TEXT-HBOUND  PIC S9(9)  COMP VALUE +10.
+      * USER DEFINED ERROR MESSAGE
+       01 UD-ERROR-MESSAGE   PIC X(80)  VALUE SPACES.
       *****************************************************             
       * SQL DECLARATION FOR VIEW ACCOUNTS                 *             
       *****************************************************             
@@ -113,19 +124,45 @@
                    AT END SET NOMORE-INPUT TO TRUE.
        GET-ALL.                                                         
                 EXEC SQL OPEN CUR1  END-EXEC.                           
+                IF SQLCODE NOT = 0 THEN
+                   MOVE 'OPEN CUR1' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
                 EXEC SQL FETCH CUR1  INTO :CUSTOMER-RECORD END-EXEC.    
-                   PERFORM PRINT-ALL                                    
+                PERFORM PRINT-ALL                                    
                      UNTIL SQLCODE IS NOT EQUAL TO ZERO.                
+                IF SQLCODE NOT = 100 THEN
+                   MOVE 'FETCH CUR1' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
                 EXEC SQL CLOSE CUR1  END-EXEC.                          
+                IF SQLCODE NOT = 0 THEN
+                   MOVE 'CLOSE CUR1' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
+                .
        PRINT-ALL.                                                       
                 PERFORM PRINT-A-LINE.                                   
                 EXEC SQL FETCH CUR1  INTO :CUSTOMER-RECORD END-EXEC.    
        GET-SPECIFIC.                                                    
                 EXEC SQL OPEN  CUR2  END-EXEC.                          
+                IF SQLCODE NOT = 0 THEN
+                   MOVE 'OPEN CUR2' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
                 EXEC SQL FETCH CUR2  INTO :CUSTOMER-RECORD END-EXEC.    
-                   PERFORM PRINT-SPECIFIC                               
+                PERFORM PRINT-SPECIFIC                               
                      UNTIL SQLCODE IS NOT EQUAL TO ZERO.                
+                IF SQLCODE NOT = 100 THEN
+                   MOVE 'FETCH CUR2' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
                 EXEC SQL CLOSE CUR2  END-EXEC.                          
+                IF SQLCODE NOT = 0 THEN
+                   MOVE 'CLOSE CUR2' TO UD-ERROR-MESSAGE
+                   PERFORM SQL-ERROR-HANDLING
+                END-IF
+                .
        PRINT-SPECIFIC.                                                  
                 PERFORM PRINT-A-LINE.                                   
                 EXEC SQL FETCH CUR2  INTO :CUSTOMER-RECORD END-EXEC.    
@@ -135,3 +172,17 @@
                 MOVE  ACCT-FIRSTN  TO  ACCT-FIRSTN-O.                   
                 MOVE  ACCT-ADDR3   TO  ACCT-ADDR3-O.                    
                 WRITE REPREC AFTER ADVANCING 2 LINES.                   
+
+       SQL-ERROR-HANDLING.
+           DISPLAY 'ERROR AT ' FUNCTION TRIM(UD-ERROR-MESSAGE, TRAILING)
+           CALL 'DSNTIAR' USING SQLCA ERROR-MESSAGE ERROR-TEXT-LEN.
+           PERFORM VARYING ERROR-INDEX FROM 1 BY 1
+                     UNTIL ERROR-INDEX > ERROR-TEXT-HBOUND
+                        OR ERROR-TEXT(ERROR-INDEX) = SPACES
+              DISPLAY FUNCTION TRIM(ERROR-TEXT(ERROR-INDEX), TRAILING)
+           END-PERFORM
+           IF SQLCODE NOT = 0 AND SQLCODE NOT = 100
+              MOVE 1000 TO RETURN-CODE
+              STOP RUN
+           END-IF
+           .

--- a/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB22R.jcl
+++ b/COBOL Programming Course #3 - Advanced Topics/Labs/jcl/CBLDB22R.jcl
@@ -7,6 +7,7 @@
 //***************************************************/
 //RUN     EXEC PGM=IKJEFT01
 //STEPLIB  DD DSN=DSNC10.SDSNLOAD,DISP=SHR
+//REPORT   DD SYSOUT=*
 //RECIN    DD *
 LINCOLN
 /*


### PR DESCRIPTION
Signed-off-by: Janos Varga <113785741+vargajb@users.noreply.github.com>

## Proposed changes

[Handling SQL error codes](https://www.ibm.com/docs/en/db2-for-zos/11?topic=statements-handling-sql-error-codes-in-cobol-applications) after the SQL statements.
If I compile the program without bind, the error message looks like this:
```
ERROR AT OPEN CUR1
 DSNT408I SQLCODE = -805, ERROR:  PACKAGE NAME DALLASC..CBLDB21.1B89E5800200F25A NOT FOUND IN PLAN Z91361. REASON 03
 DSNT418I SQLSTATE   = 51002 SQLSTATE RETURN CODE
 DSNT415I SQLERRP    = DSNXEPM SQL PROCEDURE DETECTING ERROR
 DSNT416I SQLERRD    = -251  0  0  -1  0  0 SQL DIAGNOSTIC INFORMATION
 DSNT416I SQLERRD    = X'FFFFFF05'  X'00000000'  X'00000000'  X'FFFFFFFF'  X'00000000'  X'00000000' SQL DIAGNOSTIC INFORMATION
```
If this modification is appropriate, I will also include SQL error handling in the other programs (CBLDB22.cbl and CBLDB23.cbl).

Fixes # (issue)

## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [x] Bug fix (change which fixes one or more issues)
- [x] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [ ] Documentation (change which modifies documentation related to the course)
- [x] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [x] I have included a title and description for this PR
- [x] I have DCO-signed all of my commits that are included in this PR
- [x] I have tested it manually and there are no regressions found
- [x] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)