### PR TITLE
Change to pandoc colorlinks metadata

### DIFF
--- a/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
+++ b/COBOL Programming Course #1 - Getting Started/COBOL Programming Course #1 - Getting Started.md
@@ -15,8 +15,8 @@ header-includes:
     breakatwhitespace=true,
     breakautoindent=true,
     linewidth=\textwidth}
-- \hypersetup{colorlinks=true,
-              linkcolor=blue}
+colorlinks: true
+toccolor: Blue
 ---
 \newpage
 

--- a/COBOL Programming Course #2 - Learning COBOL/COBOL Programming Course #2 - Learning COBOL.md
+++ b/COBOL Programming Course #2 - Learning COBOL/COBOL Programming Course #2 - Learning COBOL.md
@@ -15,9 +15,8 @@ header-includes:
     breakatwhitespace=true,
     breakautoindent=true,
     linewidth=\textwidth}
-- \hypersetup{colorlinks=true,
-              linkcolor=blue}
-
+colorlinks: true
+toccolor: Blue
 ---
 \newpage
 

--- a/COBOL Programming Course #3 - Advanced Topics/COBOL Programming Course #3 - Advanced Topics.md
+++ b/COBOL Programming Course #3 - Advanced Topics/COBOL Programming Course #3 - Advanced Topics.md
@@ -15,8 +15,8 @@ header-includes:
     breakatwhitespace=true,
     breakautoindent=true,
     linewidth=\textwidth}
-- \hypersetup{colorlinks=true,
-              linkcolor=blue}
+colorlinks: true
+toccolor: Blue
 ---
 \newpage
 # Resources

--- a/COBOL Programming Course #4 - Testing/COBOL Programming Course #4 - Testing.md
+++ b/COBOL Programming Course #4 - Testing/COBOL Programming Course #4 - Testing.md
@@ -15,8 +15,8 @@ header-includes:
     breakatwhitespace=true,
     breakautoindent=true,
     linewidth=\textwidth}
-- \hypersetup{colorlinks=true,
-              linkcolor=blue}
+colorlinks: true
+toccolor: Blue
 ---
 \newpage
 # Testing


### PR DESCRIPTION
Signed-off-by: Hartanto Ario Widjaya <tanto259@users.noreply.github.com>

## Proposed changes

This PR shifts the use of hypersetup link coloring from being presupposed in `header-includes` to using the `colorlinks` metadata provided by pandoc.

Pandoc shifts behaviour in March this year to move `hyperref` near the end of preamble, breaking PDF compilation in pandoc version 2.18 and above without the specific inclusion of `\usepackage`.

PDF compilation on older version of pandoc should still work. 

## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [x] Bug fix (change which fixes one or more issues)
- [ ] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [ ] Documentation (change which modifies documentation related to the course)
- [ ] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [x] I have included a title and description for this PR
- [x] I have DCO-signed all of my commits that are included in this PR
- [x] I have tested it manually and there are no regressions found
- [ ] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)