### PR TITLE
Update README.md to fix broken Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is a set of training materials and labs for COBOL on z/OS. The foll
     - [COBOL Programming Course #3 - Advanced Topics](COBOL%20Programming%20Course%20%233%20-%20Advanced%20Topics/README.md)
     - [COBOL Programming Course #4 - Testing](COBOL%20Programming%20Course%20%234%20-%20Testing/README.md)
 
-If you run into any issues, please don't hesitate to reach out on our [Slack channel](https://openmainframeproject.slack.com/archives/C011NE32Z1T).
+If you run into any issues, please don't hesitate to reach out on our [Slack channel](https://openmainframeproject.slack.com).
 
 ## Discussion
 


### PR DESCRIPTION
Change Slack link that only allows sign-ups for limited domains to generic link that allows general sign-up.

## Proposed changes

I arrived at the github page from the freecodecamp youtube video and clicked on the link to get help on slack.  When I clicked on the sign up link it prompted me to choose one of four domains allowed.  I'm not involved in any of those orgs so I went to file and issue here.  When I clicked on "new issue" it listed a lnk to slack that was different from the readme.md page so I clicked it.  That one worked.

Fixes # (issue)

## Type of change

What type of changes does your PR introduce to the COBOL Programming Course? _Put an `x` in the boxes that apply._

- [x ] Bug fix (change which fixes one or more issues)
- [ ] New feature (change which adds functionality or features to the course)
- [ ] Translations (change which adds or modifies translations of the course)
- [x] Documentation (change which modifies documentation related to the course)
- [ ] This change requires an update to the course's z/OS environment

## Checklist:

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x ] I have read the [Contributing Guideline](https://github.com/openmainframeproject/cobol-programming-course/blob/master/CONTRIBUTING.md)
- [x ] I have included a title and description for this PR
- [ ] I have DCO-signed all of my commits that are included in this PR
- [ ] I have tested it manually and there are no regressions found
- [ ] I have commented my code, particularly in hard-to-understand areas (if appropriate)
- [ ] I have made corresponding changes to the documentation (if appropriate)