### PR TITLE
Fix variable references and comment errors in lab programs

### DIFF
--- a/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL0008.cobol
+++ b/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL0008.cobol
@@ -182,8 +182,8 @@
       *    ADD ACCT-BALANCE TO TBALANCE.
       *    Or, alternatively specifying the target variable:
       *    ADD ACCT-LIMIT TO TLIMIT GIVING TLIMIT. 
-      *    ADD ACCT-BALANCE TO TBALANCE GIVING TLIMIT.
-      *    A END-COMPUTE or END-ADD stetement is optional.
+      *    ADD ACCT-BALANCE TO TBALANCE GIVING TBALANCE.
+      *    An END-COMPUTE or END-ADD statement is optional.
       *
        WRITE-RECORD.
            MOVE ACCT-NO      TO  ACCT-NO-O.

--- a/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL0009.cobol
+++ b/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL0009.cobol
@@ -151,7 +151,7 @@
            .
       * 
        WRITE-TLIMIT-TBALANCE.
-           MOVE TLIMIT   TO TLIMIT-O.
+           MOVE TLIMITED TO TLIMIT-O.
            MOVE TBALANCE TO TBALANCE-O.
            WRITE PRINT-REC FROM TRAILER-1.
            WRITE PRINT-REC FROM TRAILER-2.
@@ -171,19 +171,19 @@
       *     in order to calculate the final limit and balance report.
       *
        LIMIT-BALANCE-TOTAL.
-           COMPUTE TLIMIT   = TLIMIT   + ACCT-LIMIT   END-COMPUTE
+           COMPUTE TLIMITED = TLIMITED + ACCT-LIMIT   END-COMPUTE
            COMPUTE TBALANCE = TBALANCE + ACCT-BALANCE END-COMPUTE
            .
       *    The COMPUTE verb assigns the value of the arithmetic 
-      *    expression to the TLIMIT and TBALANCE data items.
+      *    expression to the TLIMITED and TBALANCE data items.
       *    Since the expression only includes an addition operation,
       *    the statements can also be written as:
-      *    ADD ACCT-LIMIT TO TLIMIT.
+      *    ADD ACCT-LIMIT TO TLIMITED.
       *    ADD ACCT-BALANCE TO TBALANCE.
       *    Or, alternatively specifying the target variable:
-      *    ADD ACCT-LIMIT TO TLIMIT GIVING TLIMIT. 
-      *    ADD ACCT-BALANCE TO TBALANCE GIVING TLIMIT.
-      *    A END-COMPUTE or END-ADD stetement is optional.
+      *    ADD ACCT-LIMIT TO TLIMITED GIVING TLIMITED. 
+      *    ADD ACCT-BALANCE TO TBALANCE GIVING TBALANCE.
+      *    An END-COMPUTE or END-ADD statement is optional.
       *
        WRITE-RECORD.
            MOVE ACCT-NO      TO  ACCT-NO-O.

--- a/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL006A.cobol
+++ b/COBOL Programming Course #2 - Learning COBOL/Labs/cbl/CBL006A.cobol
@@ -154,7 +154,7 @@
       *   - Adds to NEWYORK-CLIENTS counter
       
        IS-STATE-NEWYORK.
-           IF USA-STATE = 'new York' THEN
+           IF USA-STATE = 'New York' THEN
               ADD 1 TO NEWYORK-CLIENTS
            END-IF.
          


### PR DESCRIPTION
Hi,

Found a few issues in the Course #2 lab programs while working through the exercises:

**CBL0009.cobol** — doesn't compile:

The variable `TLIMIT` was renamed to `TLIMITED` in `WORKING-STORAGE SECTION` (line 50), but the references in `PROCEDURE DIVISION` still use the old name `TLIMIT`. This causes compilation errors on lines 154 and 174. The comments (lines 178–185) also still reference `TLIMIT`. Updated everything to use `TLIMITED` consistently — the program now compiles and produces the same output as CBL0008.

**CBL0008.cobol + CBL0009.cobol** — wrong GIVING target in comment example:

Line 185 shows `ADD ACCT-BALANCE TO TBALANCE GIVING TLIMIT` as an alternative form. But `GIVING` determines where the result is stored, so this would write the balance total into the limit variable. Changed to `GIVING TBALANCE`. Also fixed "stetement" → "statement" on line 186.

**CBL006A.cobol** — case mismatch in string literal:

Line 157 compares `USA-STATE = 'new York'` (lowercase 'n'), but the data has 'New York' with a capital 'N'. Since COBOL string comparison is case-sensitive, the counter for New York clients would always stay at zero. The comment on line 162 and the CBLC1.cobol version both use 'New York' with the correct capitalization.

I checked the course markdown to make sure I'm not "fixing" any intentional debugging exercises (CBL0002, CBL0007, CBL0012) — those are untouched.

Related: #324

Made with [Cursor](https://cursor.com)